### PR TITLE
Added optional support for https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ nbproject
 config/local.json
 config/development.json
 config/production.json
+backend/config/ssl
 backend/config/local.json
 backend/config/development.json
 backend/config/production.json

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,4 +1,6 @@
 var express = require('express');
+var http = require('http');
+var https = require('https');
 var session = require('express-session');
 var path = require('path');
 var winston = require('winston');
@@ -105,8 +107,15 @@ app.use(function(err, req, res, next) {
   console.error(err.stack);
   next(err);
 });
-  
-app.listen(conf.nodejs_port, function() {
-  console.log('Express server listening on port %d in %s mode',
+
+if (conf.ssl) {
+  var server = https.createServer(conf.ssl_options, app).listen(conf.nodejs_port, function(){
+  console.log('Express server listening on port %d in %s mode (https)',
     conf.nodejs_port, app.get('env'));
-});
+  });
+} else {
+  var server = http.createServer(app).listen(conf.nodejs_port, function(){
+  console.log('Express server listening on port %d in %s mode (http)',
+    conf.nodejs_port, app.get('env'));
+  });
+}

--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -7,6 +7,14 @@ var config
 try {
   // config = require(config_file);
   config = (JSON.parse(fs.readFileSync(config_file, "utf8")));
+  config.ssl = false;
+  if ( config.ssl_options
+      && fs.existsSync(__dirname + "/" + config.ssl_options.ssl_key)
+      && fs.existsSync(__dirname + "/" + config.ssl_options.ssl_cert)) {
+    config.ssl = true;
+    config.ssl_options.key = fs.readFileSync(__dirname + "/" + config.ssl_options.ssl_key);
+    config.ssl_options.cert = fs.readFileSync(__dirname + "/" + config.ssl_options.ssl_cert);
+  }
 } catch (err) {
   if (err.code && err.code === 'MODULE_NOT_FOUND') {
     console.error('No config file matching NODE_ENV=' + process.env.NODE_ENV 


### PR DESCRIPTION
https support is optional. It is enabled if a certificate and a private key are found. Example configuration:

```
{
  "mongo_server": "127.0.0.1",
  "mongo_options": {
    "db": { "native_parser": true}
  },
  "mongo_db": "agora_dev",
  "ssl_options": {
    "ssl_key": "ssl/server.key",
    "ssl_cert": "ssl/server.crt",
    "secureProtocol": "TLSv1_method"
  },
  "nodejs_port": 8081
}
```
