### PR TITLE
Adds AttributeConsumingService to the metadata

### DIFF
--- a/backend/lib/passport-saml-dynamic-idp/saml.js
+++ b/backend/lib/passport-saml-dynamic-idp/saml.js
@@ -738,10 +738,42 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
           '@isDefault': 'true',
           '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
           '@Location': this.options.callbackUrl
+        },
+        'AttributeConsumingService' : {
+          '@index': '0',
+          '@isDefault': 'true',
+          'ServiceName': {
+            '@xml:lang': 'en',
+            '#text': this.options.serviceName
+          },
+          'ServiceDescription': {
+          '@xml:lang': 'en',
+          '#text': this.options.serviceDescription
+          }
         }
       },
     }
   };
+
+  var requestedAttributesArray = new Array;
+  if (this.options.requestedAttributes) {
+    this.options.requestedAttributes.forEach(function(attr) {
+      requestedAttributesArray.push({
+        'RequestedAttribute': {
+          '@FriendlyName': attr.FriendlyName,
+          '@Name': attr.Name,
+          '@NameFormat': attr.NameFormat,
+          '@isRequired': attr.isRequired
+        }
+      });
+    });
+  }
+
+  if (requestedAttributesArray.length > 0) {
+    metadata.EntityDescriptor
+            .SPSSODescriptor
+            .AttributeConsumingService['#list'] = requestedAttributesArray;
+  }
 
   return xmlbuilder.create(metadata).end({ pretty: true, indent: '  ', newline: '\n' });
 };

--- a/backend/routes/saml_metadata.js
+++ b/backend/routes/saml_metadata.js
@@ -10,6 +10,9 @@ router.get('/', function(req, res, next) {
     path: conf.passport.saml.path,
     callbackUrl: conf.passport.saml.callbackUrl,
     identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
+    serviceName: conf.passport.saml.serviceName,
+    serviceDescription: conf.passport.saml.serviceDescription,
+    requestedAttributes: conf.passport.saml.requestedAttributes
   };
   var strategy = new SamlStrategy( samlConfig, function() {} );
   res.set('Content-Type', 'text/xml');


### PR DESCRIPTION
Adds:
- ServiceName
- ServiceDescription
- RequestedAttributes

Example configuration:

```
  "passport": {
    "saml": {
      "path": "/saml/login/callback",
      "callbackUrl": "https://127.0.0.1:8081/saml/login/callback",
      "entryPoint": "https://openidp.feide.no/simplesaml/saml2/idp/SSOService.php",
      "issuer": "https://127.0.0.1:8081/saml2/entityid",
      "serviceName": "GEANT Cloud Catalogue",
      "serviceDescription": "GEANT Cloud Catalogue",
      "requestedAttributes":[
        {
          "FriendlyName": "eduPersonTargetedID",
          "Name": "urn:oid:1.3.6.1.4.1.5923.1.1.1.10",
          "NameFormat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
          "isRequired": "true"
        },
        {
          "FriendlyName": "eduPersonPrincipalName",
          "Name": "urn:oid:1.3.6.1.4.1.5923.1.1.1.6",
          "NameFormat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
          "isRequired": "true"
        },
        {
          "FriendlyName": "mail",
          "Name": "urn:oid:0.9.2342.19200300.100.1.3",
          "NameFormat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
          "isRequired": "false"
        },
        {
          "FriendlyName": "cn",
          "Name": "urn:oid:2.5.4.3",
          "NameFormat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
          "isRequired": "false"
        },
        {
          "FriendlyName": "displayName",
          "Name": "urn:oid:2.16.840.1.113730.3.1.241",
          "NameFormat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
          "isRequired": "false"
        },
        {
          "FriendlyName": "givenName",
          "Name": "urn:oid:2.5.4.42",
          "NameFormat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
          "isRequired": "false"
        },
        {
          "FriendlyName": "surname",
          "Name": "urn:oid:2.5.4.4",
          "NameFormat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
          "isRequired": "false"
        }
      ]
    }
}
```
