### PR TITLE
Adds support for separate auth/enc keys

### DIFF
--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -15,6 +15,20 @@ try {
     config.ssl_options.key = fs.readFileSync(__dirname + "/" + config.ssl_options.ssl_key);
     config.ssl_options.cert = fs.readFileSync(__dirname + "/" + config.ssl_options.ssl_cert);
   }
+  if ( config.passport.saml.publicCertName
+        && config.passport.saml.privateCertName
+        && fs.existsSync(__dirname + "/" + config.passport.saml.publicCertName)
+        && fs.existsSync(__dirname + "/" + config.passport.saml.privateCertName)) {
+    config.passport.saml.publicCert = fs.readFileSync(__dirname + "/" + config.passport.saml.publicCertName, 'utf-8');
+    config.passport.saml.privateCert = fs.readFileSync(__dirname + "/" + config.passport.saml.privateCertName, 'utf-8');
+  }
+  if ( config.passport.saml.decryptionCertName
+        && config.passport.saml.decryptionPvkName
+        && fs.existsSync(__dirname + "/" + config.passport.saml.decryptionCertName)
+        && fs.existsSync(__dirname + "/" + config.passport.saml.decryptionPvkName)) {
+    config.passport.saml.decryptionCert = fs.readFileSync(__dirname + "/" + config.passport.saml.decryptionCertName, 'utf-8');
+    config.passport.saml.decryptionPvk = fs.readFileSync(__dirname + "/" + config.passport.saml.decryptionPvkName, 'utf-8');
+  }
 } catch (err) {
   if (err.code && err.code === 'MODULE_NOT_FOUND') {
     console.error('No config file matching NODE_ENV=' + process.env.NODE_ENV 

--- a/backend/routes/saml_metadata.js
+++ b/backend/routes/saml_metadata.js
@@ -12,7 +12,11 @@ router.get('/', function(req, res, next) {
     identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
     serviceName: conf.passport.saml.serviceName,
     serviceDescription: conf.passport.saml.serviceDescription,
-    requestedAttributes: conf.passport.saml.requestedAttributes
+    requestedAttributes: conf.passport.saml.requestedAttributes,
+    decryptionCert: conf.passport.saml.decryptionCert,
+    decryptionPvk: conf.passport.saml.decryptionPvk,
+    privateCert: conf.passport.saml.privateCert,
+    publicCert: conf.passport.saml.publicCert
   };
   var strategy = new SamlStrategy( samlConfig, function() {} );
   res.set('Content-Type', 'text/xml');


### PR DESCRIPTION
- If privateCert and publicCert are defined, then publish the publicCert
  in the metadata as KeyDescriptor with use = "sign" and the decryptCert
  as KeyDescriptor with use = "encryption"
- If privateCert and publicCert are not defined and decryptCert,
  decryptPvk are defined, then publish decryptCert in the metadata as
  KeyDiscriptor with no use attribute
- If no certificates are defined, then skip KeyDescriptor altogther

Example configuration:

```
"passport": {
  "saml": {
    "decryptionCertName": "ssl/saml-encrypt.crt",
    "decryptionPvkName": "ssl/saml-encrypt.key",
    "publicCertName": "ssl/saml-sign.crt",
    "privateCertName": "ssl/saml-sign.key"
  }
}
```
