### PR TITLE
Uses same SAML configuration for login & metadata

### DIFF
--- a/backend/config/passport.js
+++ b/backend/config/passport.js
@@ -1,6 +1,6 @@
 var SamlStrategy = require('../lib/passport-saml-dynamic-idp').Strategy;
 
-module.exports = function (passport, config) {
+module.exports = function (passport, conf) {
 
   passport.serializeUser(function(user, done) {
     done(null, user);
@@ -11,10 +11,19 @@ module.exports = function (passport, config) {
   });
   
   passport.use(new SamlStrategy({
-      path: config.passport.saml.path,
-      entryPoint: config.passport.saml.entryPoint,
-      issuer: config.passport.saml.issuer
-    //privateCert: config.passport.saml.privateCert
+    path: conf.passport.saml.path,
+    entryPoint: conf.passport.saml.entryPoint,
+    issuer: conf.passport.saml.issuer,
+    callbackUrl: conf.passport.saml.callbackUrl,
+    identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
+    serviceName: conf.passport.saml.serviceName,
+    serviceDescription: conf.passport.saml.serviceDescription,
+    requestedAttributes: conf.passport.saml.requestedAttributes,
+    decryptionCert: conf.passport.saml.decryptionCert,
+    decryptionPvk: conf.passport.saml.decryptionPvk,
+    privateCert: conf.passport.saml.privateCert,
+    publicCert: conf.passport.saml.publicCert,
+    disableRequestedAuthnContext: conf.passport.saml.disableRequestedAuthnContext
   },
   function(profile, done) {
     return done(null, {


### PR DESCRIPTION
- Adds missing configuration attribution to the login SAML configuration
- Changes the name of the variable from config to conf
