### PR TITLE
Adds basic attribute mappings

### DIFF
--- a/backend/config/passport.js
+++ b/backend/config/passport.js
@@ -26,12 +26,29 @@ module.exports = function (passport, conf) {
     disableRequestedAuthnContext: conf.passport.saml.disableRequestedAuthnContext
   },
   function(profile, done) {
+    id = profile.nameID ||
+          profile['urn:oid:1.3.6.1.4.1.5923.1.1.1.10'] ||
+          profile.eduPersonTargetedID ||
+          profile['urn:oid:1.3.6.1.4.1.5923.1.1.1.6'] ||
+          profile.eduPersonPrincipalName ;
+
+    email = profile['urn:oid:0.9.2342.19200300.100.1.3'] ||
+            profile.mail ||
+            profile.email ;
+
+    displayName = profile['urn:oid:0.9.2342.19200300.100.1.3'] ||
+                  profile.displayName ||
+                  profile['urn:oid:2.5.4.3'] ||
+                  profile.cn ;
+
+    firstName = profile['urn:oid:2.5.4.42'] || profile.givenName ;
+    lastName = profile['urn:oid:2.5.4.4'] || profile.sn ;
     return done(null, {
-      id : profile.uid,
-      email : profile.email,
-      displayName : profile.cn,
-      firstName : profile.givenName,
-      lastName : profile.sn
+      id : id,
+      email : email,
+      displayName : displayName,
+      firstName : firstName,
+      lastName : lastName
     });
   })
 );


### PR DESCRIPTION
The naming of the attributes in the SAML response might defer from IdP
to IdP. For example, from GN VHO we retrieve:

```
{
  issuer: {
    _: 'https://gn-vho.grnet.gr/idp/shibboleth',
    '$': {
       Format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:entity'
    }
  },
  nameID: '_5fb2b934dc89bd8da860e7a32e5a9e5b',
  nameIDFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
  'urn:oid:1.3.6.1.4.1.5923.1.1.1.6': '99999@gn-vho.grnet.gr',
  'urn:oid:2.5.4.3': 'LastName FirstName',
  'urn:oid:2.5.4.4': 'LastName',
  'urn:oid:2.5.4.42': 'FirstName',
  'urn:oid:0.9.2342.19200300.100.1.3': 'mail@example.com',
  'urn:oid:1.3.6.1.4.1.5923.1.1.1.10': undefined,
  'urn:oid:2.16.840.1.113730.3.1.241': 'FirstName LastName',
  mail: 'mail@example.com',
  email: 'mail@example.com'
}
```

While from the OpenIdP:

```
{
  issuer: 'https://openidp.feide.no',
  nameID: '_d3e0a5fa8face9d978050beb1595f99f2b7177ac56',
  nameIDFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
  uid: 'user',
  mail: 'mail@example.com',
  sn: 'LastName',
  eduPersonPrincipalName: 'user@rnd.feide.no',
  cn: 'FirstName LastName',
  givenName: 'FirstName',
  eduPersonTargetedID: '2895b90b900a91dbd5282f9fa39a9d19e93ab8fa',
  'urn:oid:0.9.2342.19200300.100.1.1': 'user',
  'urn:oid:0.9.2342.19200300.100.1.3': 'mail@example.com',
  'urn:oid:2.5.4.4': 'LastName',
  'urn:oid:1.3.6.1.4.1.5923.1.1.1.6': 'user@rnd.feide.no',
  'urn:oid:2.5.4.3': 'FirstName LastName',
  'urn:oid:2.5.4.42': 'FirstName',
  'urn:oid:1.3.6.1.4.1.5923.1.1.1.10': '2895b90b900a91dbd5282f9fa39a9d19e93ab8fa',
  email: 'mail@example.com'
 }
```

This commit adds basic support for attribute mapping
